### PR TITLE
corrected spelling when hubot forgets

### DIFF
--- a/src/remember-multiline.coffee
+++ b/src/remember-multiline.coffee
@@ -80,4 +80,4 @@ module.exports = (robot) ->
     if value?
       msg.send "I've forgotten #{key} is #{value}"
     else
-      msg.send "I've alredy forgotten #{key}"
+      msg.send "I've already forgotten #{key}"

--- a/test/remember-multiline-test.coffee
+++ b/test/remember-multiline-test.coffee
@@ -72,7 +72,7 @@ describe 'remember-multiline', ->
     context 'with non-existent key', ->
       it 'notifies non-existent key', ->
         hubot.text('hubot forget key0').then (response) ->
-          expect(response).to.equal("I've alredy forgotten key0")
+          expect(response).to.equal("I've already forgotten key0")
           expect(robot.brain.get('remember')).to.deep.equal(key1: 'value1', key2: 'value2')
 
     context 'with existent key with hyphen', ->


### PR DESCRIPTION
Simple correction of a spelling error. When hubot forgot something, he said "alredy", when it should be "already"
